### PR TITLE
Decrease ping interval to 30 seconds

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -92,7 +92,7 @@ const interval = setInterval(() => {
     ws.isAlive = false;
     ws.ping(noop);
   });
-}, 60000);
+}, 30000);
 
 startEmitter();
 // this event is triggered with every new block see events.ts


### PR DESCRIPTION
60 seconds is too close to Nginxes default proxy read/write timeout

```
Default: proxy_read_timeout 60s;
```