### PR TITLE
fix: detect rollback and prevent emitting too many blocks

### DIFF
--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -1,0 +1,4 @@
+// BIP44 gap limit https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#address-gap-limit
+export const ADDRESS_GAP_LIMIT = 20;
+// Skip emitting of `newBlock` event for missed blocks if we missed more than defined number of them
+export const EMIT_MAX_MISSED_BLOCKS = 3;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -37,6 +37,4 @@ export const MESSAGES_RESPONSE = {
   CONNECT: 'CONNECT',
 } as const;
 
-export const ADDRESS_GAP_LIMIT = 20;
-
 export const WELCOME_MESSAGE = `Hello there! see: <a href="${REPOSITORY_URL}">${REPOSITORY_URL}</a>`;

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,4 +1,4 @@
-import { ADDRESS_GAP_LIMIT } from '../constants';
+import { ADDRESS_GAP_LIMIT } from '../constants/config';
 import * as Addresses from '../types/address';
 import { blockfrostAPI } from '../utils/blockfrostAPI';
 import {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -50,7 +50,7 @@ export const promiseTimeout = <T>(promise: T, ms: number) => {
   const timeout = new Promise((_resolve, reject) => {
     const id = setTimeout(() => {
       clearTimeout(id);
-      reject('Timed out in ' + ms + 'ms.');
+      reject(Error('PROMISE_TIMEOUT'));
     }, ms);
   });
 


### PR DESCRIPTION
resolves: https://github.com/blockfrost/blockfrost-websocket-link/issues/155