### PR TITLE
refactor: optimize message validator

### DIFF
--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -72,19 +72,21 @@ const schemas: { [k in Validators]: { properties: unknown; required?: string[] }
 } as const;
 
 export const validators = Object.fromEntries(
-  Object.entries(schemas).map(([title, schema]) => [
-    title,
-    (data: unknown) => {
-      const validator = ajv.compile({
-        $schema: 'http://json-schema.org/draft-07/schema#',
-        title,
-        type: 'object',
-        ...schema,
-      });
+  Object.entries(schemas).map(([title, schema]) => {
+    const validator = ajv.compile({
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      title,
+      type: 'object',
+      ...schema,
+    });
 
-      if (!validator(data)) throw new MessageError(JSON.stringify(validator.errors));
-    },
-  ]),
+    return [
+      title,
+      (data: unknown) => {
+        if (!validator(data)) throw new MessageError(JSON.stringify(validator.errors));
+      },
+    ];
+  }),
 ) as { [k in Validators]: (data: unknown) => void };
 
 export const getMessage = (message: string) => {


### PR DESCRIPTION
I noticed a not negligible issue: `ajv.compile` is called:

1. at each message validation;
2. only when there is a message to be validated.

This change has two benefits:

1. the schema is compiled only once, at service startup
2. all the schemas are validated at service startup helping spotting ASAP eventual errors introduced to the schemas.