### PR TITLE
refactor: remove pLimiter code repetition

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -144,7 +144,7 @@ export const onBlock = async (
 
     // fetch txs that include client's address with their utxo data
     const txs = await getTransactionsWithDetails(
-      Object.entries(txsCbor).map(([txid, cbor]) => ({ txid, cbor })),
+      Object.entries(txsCbor).map(([txId, cbor]) => ({ txId, cbor })),
     );
 
     const notifications: TxNotification[] = [];

--- a/src/methods/get-account-info.ts
+++ b/src/methods/get-account-info.ts
@@ -116,7 +116,7 @@ export const getAccountInfo = async (
     } else if (details === 'txs') {
       // fetch full transaction objects and set account.history.transactions
       const txs = await txIdsToTransactions(
-        requestedPageTxIds.map(item => ({ address: item.address, data: [item.tx_hash] })),
+        requestedPageTxIds.map(item => ({ address: item.address, txIds: [item.tx_hash] })),
       );
 
       accountInfo.history.transactions = txs;

--- a/src/methods/get-balance-history.ts
+++ b/src/methods/get-balance-history.ts
@@ -136,7 +136,7 @@ export const getAccountBalanceHistory = async (
     await txIdsToTransactions(
       txIds.map(tx => ({
         address: tx.address,
-        data: [tx.tx_hash],
+        txIds: [tx.tx_hash],
       })),
     )
   )

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -8,7 +8,7 @@ import {
 } from '@blockfrost/blockfrost-js';
 import memoizee from 'memoizee';
 import { getAssetData, transformAsset } from './asset.js';
-import { assetMetadataLimiter, pLimiter } from './limiter.js';
+import { assetMetadataLimiter, limiter } from './limiter.js';
 
 export const deriveAddress = (
   publicKey: string,
@@ -69,9 +69,7 @@ export const discoverAddresses = async (
       );
 
       addressCount++;
-      const promise = pLimiter.add(() => blockfrostAPI.addresses(address), {
-        throwOnTimeout: true,
-      });
+      const promise = limiter(() => blockfrostAPI.addresses(address));
 
       promisesBundle.push({ address, promise, path });
     }
@@ -113,17 +111,15 @@ export const addressesToUtxos = async (
   const promises = addresses.map(item =>
     item.data === 'empty'
       ? []
-      : pLimiter.add(
-          () =>
-            // change batchSize to fetch only 1 page at a time (each page has 100 utxos)
-            blockfrostAPI.addressesUtxosAll(item.address, { batchSize: 1 }).catch(error => {
-              if (error instanceof BlockfrostServerError && error.status_code === 404) {
-                return [];
-              } else {
-                throw error;
-              }
-            }),
-          { throwOnTimeout: true },
+      : limiter(() =>
+          // change batchSize to fetch only 1 page at a time (each page has 100 utxos)
+          blockfrostAPI.addressesUtxosAll(item.address, { batchSize: 1 }).catch(error => {
+            if (error instanceof BlockfrostServerError && error.status_code === 404) {
+              return [];
+            } else {
+              throw error;
+            }
+          }),
         ),
   );
 
@@ -167,15 +163,13 @@ export const utxosWithBlocks = async (
     if (utxo.data === 'empty') continue;
 
     for (const utxoData of utxo.data) {
-      const promise = pLimiter.add(
-        () =>
-          blockfrostAPI.blocks(utxoData.block).then(blockData => ({
-            address: utxo.address,
-            path: utxo.path,
-            utxoData: utxoData,
-            blockInfo: blockData,
-          })),
-        { throwOnTimeout: true },
+      const promise = limiter(() =>
+        blockfrostAPI.blocks(utxoData.block).then(blockData => ({
+          address: utxo.address,
+          path: utxo.path,
+          utxoData: utxoData,
+          blockInfo: blockData,
+        })),
       );
 
       promisesBundle.push(promise);
@@ -198,27 +192,25 @@ export const addressesToTxIds = async (
   for (const item of addresses) {
     if (item.data === 'empty') continue;
 
-    const promise = pLimiter.add(
-      () =>
-        // 1 page (100 txs) per address at a time should be more efficient default value
-        // compared to fetching 10 pages (1000 txs) per address
-        blockfrostAPI
-          .addressesTransactionsAll(item.address, { batchSize: 1 })
-          .then(data => ({
-            address: item.address,
-            data,
-          }))
-          .catch(error => {
-            if (error instanceof BlockfrostServerError && error.status_code === 404) {
-              return {
-                address: item.address,
-                data: [],
-              };
-            } else {
-              throw error;
-            }
-          }),
-      { throwOnTimeout: true },
+    const promise = limiter(() =>
+      // 1 page (100 txs) per address at a time should be more efficient default value
+      // compared to fetching 10 pages (1000 txs) per address
+      blockfrostAPI
+        .addressesTransactionsAll(item.address, { batchSize: 1 })
+        .then(data => ({
+          address: item.address,
+          data,
+        }))
+        .catch(error => {
+          if (error instanceof BlockfrostServerError && error.status_code === 404) {
+            return {
+              address: item.address,
+              data: [],
+            };
+          } else {
+            throw error;
+          }
+        }),
     );
 
     promisesBundle.push(promise);
@@ -244,22 +236,20 @@ export const getAddressesData = async (
   }
 
   const promises = addresses.map(addr =>
-    pLimiter.add(
-      () =>
-        blockfrostAPI.addressesTotal(addr.address).catch(error => {
-          if (error.status_code === 404) {
-            return {
-              address: addr.address,
-              path: addr.path,
-              tx_count: 0,
-              received_sum: [{ unit: 'lovelace', quantity: '0' }],
-              sent_sum: [{ unit: 'lovelace', quantity: '0' }],
-            };
-          } else {
-            throw new Error(error);
-          }
-        }),
-      { throwOnTimeout: true },
+    limiter(() =>
+      blockfrostAPI.addressesTotal(addr.address).catch(error => {
+        if (error.status_code === 404) {
+          return {
+            address: addr.address,
+            path: addr.path,
+            tx_count: 0,
+            received_sum: [{ unit: 'lovelace', quantity: '0' }],
+            sent_sum: [{ unit: 'lovelace', quantity: '0' }],
+          };
+        } else {
+          throw new Error(error);
+        }
+      }),
     ),
   );
   const responses = await Promise.all(promises);

--- a/src/utils/limiter.ts
+++ b/src/utils/limiter.ts
@@ -28,3 +28,6 @@ pLimiter.on('error', error => {
 ratesLimiter.on('error', error => {
   logger.warn(`ratesLimiter error`, error);
 });
+
+export const limiter = <T>(task: () => PromiseLike<T>) =>
+  pLimiter.add<T>(task, { throwOnTimeout: true });

--- a/test/unit/tests/utils/events.test.ts
+++ b/test/unit/tests/utils/events.test.ts
@@ -153,7 +153,7 @@ describe('events', () => {
           return new Promise(resolve => {
             // sanity check that the test really wanted to fetch transactions that we expected
             for (const mockedTx of fixture.mocks.txsWithUtxo) {
-              if (!txs.find(({ txid }) => mockedTx.txData.hash === txid)) {
+              if (!txs.find(({ txId }) => mockedTx.txData.hash === txId)) {
                 throw new Error('Unexpected list of affected addresses');
               }
             }


### PR DESCRIPTION
Apart from when it is used to gather stats, `pLimiter` is always used with `pLimiter.add(task, { throwOnTimeout: true })`.

This PR add the `limiter` utility to remove this code repetition also increasing a bit the readability.