### PR TITLE
feat: make fetchTransactionData able to fetch CBOR as well

### DIFF
--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -78,4 +78,6 @@ export interface TransformedTransaction {
   redeemer_count: number;
   /** True if contract script passed validation */
   valid_contract: boolean;
+  /** The CBOR representation of the transaction */
+  cbor?: string;
 }


### PR DESCRIPTION
This small PR prepares the changes for #253 .

- Adds `cbor?: string` to `TransformedTransaction`.
- Makes `fetchTransactionData` able to fetch tx CBOR as well.
- Unifies how the types are imported.